### PR TITLE
Initialize minimal Python project skeleton

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,9 @@
+root = true
+
+[*]
+end_of_line = lf
+charset = utf-8
+indent_style = space
+indent_size = 4
+insert_final_newline = true
+trim_trailing_whitespace = true

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,16 @@
+# Virtual environments
+.venv/
+venv/
+
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# Caches
+.pytest_cache/
+.ruff_cache/
+.mypy_cache/
+
+# macOS
+.DS_Store

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,13 @@
+.PHONY: run test format lint
+
+run:
+python -m src.app.main
+
+test:
+pytest -q
+
+format:
+black .
+
+lint:
+ruff check .

--- a/README.md
+++ b/README.md
@@ -1,1 +1,15 @@
-# bb13082025
+# Sample App
+
+A minimal Python project skeleton.
+
+## Setup and Usage
+
+```bash
+python -m venv .venv
+. .venv/bin/activate  # Windows: .venv\Scripts\activate
+pip install -r requirements.txt -r requirements-dev.txt
+make run
+make test
+make format
+make lint
+```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,14 @@
+[project]
+name = "sample-app"
+version = "0.1.0"
+requires-python = ">=3.11"
+
+[tool.black]
+line-length = 100
+
+[tool.ruff]
+line-length = 100
+target-version = "py311"
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,3 @@
+pytest
+black
+ruff

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,1 @@
+# No runtime dependencies

--- a/src/app/__init__.py
+++ b/src/app/__init__.py
@@ -1,0 +1,3 @@
+"""Application package."""
+
+__all__ = ["main"]

--- a/src/app/main.py
+++ b/src/app/main.py
@@ -1,0 +1,10 @@
+"""Entry point for the sample application."""
+
+
+def main() -> None:
+    """Run the application."""
+    print("Hello world")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -1,0 +1,8 @@
+"""Smoke tests for the sample application."""
+
+from src.app import main
+
+
+def test_main_callable() -> None:
+    """Ensure main function is callable."""
+    assert callable(main.main)


### PR DESCRIPTION
## Summary
- scaffold minimal Python application with entrypoint and smoke test
- add project configuration, dependencies, and development tooling

## Testing
- no tests were run

------
https://chatgpt.com/codex/tasks/task_e_689c844584008328bb923a268966cec1