### PR TITLE
Add Telegram bot module with basic handlers

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ pycryptodome==3.23.0
 python-dotenv
 requests==2.32.4
 requests-toolbelt==1.0.0
+python-telegram-bot==20.7

--- a/src/app/__init__.py
+++ b/src/app/__init__.py
@@ -1,4 +1,3 @@
 """Application package."""
 
-__all__ = ["api_client", "config", "main"]
-
+__all__ = ["api_client", "config", "main", "bot", "controller"]

--- a/src/app/bot/__init__.py
+++ b/src/app/bot/__init__.py
@@ -1,0 +1,5 @@
+"""Telegram bot package."""
+
+from .bot import create_application, run_bot
+
+__all__ = ["create_application", "run_bot"]

--- a/src/app/bot/bot.py
+++ b/src/app/bot/bot.py
@@ -1,0 +1,44 @@
+"""Utilities to create and run the Telegram bot."""
+
+from __future__ import annotations
+
+import logging
+from telegram.ext import (
+    Application,
+    ApplicationBuilder,
+    CommandHandler,
+    ContextTypes,
+)
+
+from .config import BotSettings
+from . import handlers
+from ..controller import AppController
+
+logger = logging.getLogger(__name__)
+
+
+async def _error_handler(update: object, context: ContextTypes.DEFAULT_TYPE) -> None:
+    logger.exception("Unhandled exception: %s", context.error)
+
+
+def create_application(
+    controller: AppController, settings: BotSettings | None = None
+) -> Application:
+    """Create and configure the Telegram application."""
+    settings = settings or BotSettings.from_env()
+    application = ApplicationBuilder().token(settings.token).build()
+    application.bot_data["controller"] = controller
+    application.bot_data["admin_id"] = settings.admin_id
+
+    application.add_handler(CommandHandler("start", handlers.start))
+    application.add_handler(CommandHandler("stop", handlers.stop))
+    application.add_handler(CommandHandler("status", handlers.status))
+    application.add_error_handler(_error_handler)
+    return application
+
+
+def run_bot(controller: AppController, settings: BotSettings | None = None) -> None:
+    """Run the bot using polling."""
+    application = create_application(controller, settings)
+    logger.info("Bot starting polling")
+    application.run_polling()

--- a/src/app/bot/config.py
+++ b/src/app/bot/config.py
@@ -1,0 +1,35 @@
+"""Configuration for the Telegram bot."""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+from dotenv import load_dotenv
+
+load_dotenv()
+
+
+def _env_int(name: str) -> int:
+    value = os.getenv(name)
+    if value is None:
+        raise RuntimeError(f"{name} environment variable is required")
+    try:
+        return int(value)
+    except ValueError as exc:
+        raise RuntimeError(f"{name} must be an integer") from exc
+
+
+@dataclass
+class BotSettings:
+    """Settings loaded from environment variables."""
+
+    token: str
+    admin_id: int
+
+    @classmethod
+    def from_env(cls) -> "BotSettings":
+        token = os.getenv("TG_BOT_TOKEN")
+        if not token:
+            raise RuntimeError("TG_BOT_TOKEN environment variable is required")
+        admin_id = _env_int("TG_ADMIN_ID")
+        return cls(token=token, admin_id=admin_id)

--- a/src/app/bot/handlers.py
+++ b/src/app/bot/handlers.py
@@ -1,0 +1,69 @@
+"""Command handlers for the Telegram bot."""
+
+from __future__ import annotations
+
+import logging
+from telegram import Update
+from telegram.ext import ContextTypes
+
+from ..controller import AppController
+
+logger = logging.getLogger(__name__)
+
+
+def _controller(context: ContextTypes.DEFAULT_TYPE) -> AppController:
+    controller = context.application.bot_data.get("controller")
+    if not isinstance(controller, AppController):
+        raise RuntimeError("Controller is not configured")
+    return controller
+
+
+def _is_authorized(update: Update, context: ContextTypes.DEFAULT_TYPE) -> bool:
+    admin_id = context.application.bot_data.get("admin_id")
+    user = update.effective_user
+    return user is not None and admin_id == user.id
+
+
+async def start(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+    """Handle the /start command."""
+    if not _is_authorized(update, context):
+        await update.effective_message.reply_text("Unauthorized")
+        logger.warning("Unauthorized /start attempt by user %s", update.effective_user)
+        return
+    controller = _controller(context)
+    try:
+        message = controller.start()
+        await update.effective_message.reply_text(message)
+    except Exception:
+        logger.exception("Error handling /start")
+        await update.effective_message.reply_text("Failed to start the application.")
+
+
+async def stop(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+    """Handle the /stop command."""
+    if not _is_authorized(update, context):
+        await update.effective_message.reply_text("Unauthorized")
+        logger.warning("Unauthorized /stop attempt by user %s", update.effective_user)
+        return
+    controller = _controller(context)
+    try:
+        message = controller.stop()
+        await update.effective_message.reply_text(message)
+    except Exception:
+        logger.exception("Error handling /stop")
+        await update.effective_message.reply_text("Failed to stop the application.")
+
+
+async def status(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+    """Handle the /status command."""
+    if not _is_authorized(update, context):
+        await update.effective_message.reply_text("Unauthorized")
+        logger.warning("Unauthorized /status attempt by user %s", update.effective_user)
+        return
+    controller = _controller(context)
+    try:
+        message = controller.status()
+        await update.effective_message.reply_text(message)
+    except Exception:
+        logger.exception("Error handling /status")
+        await update.effective_message.reply_text("Failed to retrieve status.")

--- a/src/app/controller.py
+++ b/src/app/controller.py
@@ -1,0 +1,41 @@
+"""Application-level business logic."""
+
+from __future__ import annotations
+
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+class AppController:
+    """Encapsulates simple application state.
+
+    The controller exposes methods that can be triggered from the Telegram bot
+    handlers. In a real application this would coordinate services and contain
+    the business rules.
+    """
+
+    def __init__(self) -> None:
+        self._running = False
+
+    def start(self) -> str:
+        """Start the application."""
+        if not self._running:
+            self._running = True
+            logger.info("Application started")
+            return "Application started."
+        logger.info("Start requested while already running")
+        return "Application is already running."
+
+    def stop(self) -> str:
+        """Stop the application."""
+        if self._running:
+            self._running = False
+            logger.info("Application stopped")
+            return "Application stopped."
+        logger.info("Stop requested while not running")
+        return "Application is not running."
+
+    def status(self) -> str:
+        """Return the running status."""
+        return "Application is running." if self._running else "Application is stopped."

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -1,0 +1,17 @@
+"""Tests for the AppController class."""
+
+from src.app.controller import AppController
+
+
+def test_start_and_status() -> None:
+    controller = AppController()
+    assert controller.status() == "Application is stopped."
+    assert controller.start() == "Application started."
+    assert controller.status() == "Application is running."
+
+
+def test_stop() -> None:
+    controller = AppController()
+    controller.start()
+    assert controller.stop() == "Application stopped."
+    assert controller.status() == "Application is stopped."


### PR DESCRIPTION
## Summary
- add Telegram bot package with configuration and handlers for `/start`, `/stop`, `/status`
- introduce AppController for simple business logic
- include basic tests for the controller

## Testing
- `black --check src/app/controller.py src/app/bot tests/test_controller.py`
- `ruff check src/app/controller.py src/app/bot tests/test_controller.py`
- `PYTHONPATH=. pytest`


------
https://chatgpt.com/codex/tasks/task_e_689f9a89ebe08328aff36f805cf1b91c