### PR TITLE
Add async task management to AppController

### DIFF
--- a/src/app/bot/handlers.py
+++ b/src/app/bot/handlers.py
@@ -32,8 +32,8 @@ async def start(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
         return
     controller = _controller(context)
     try:
-        message = controller.start()
-        await update.effective_message.reply_text(message)
+        status = controller.start()
+        await update.effective_message.reply_text(f"Application is {status.state.value}.")
     except Exception:
         logger.exception("Error handling /start")
         await update.effective_message.reply_text("Failed to start the application.")
@@ -47,8 +47,8 @@ async def stop(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
         return
     controller = _controller(context)
     try:
-        message = controller.stop()
-        await update.effective_message.reply_text(message)
+        status = controller.stop()
+        await update.effective_message.reply_text(f"Application is {status.state.value}.")
     except Exception:
         logger.exception("Error handling /stop")
         await update.effective_message.reply_text("Failed to stop the application.")
@@ -62,8 +62,8 @@ async def status(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
         return
     controller = _controller(context)
     try:
-        message = controller.status()
-        await update.effective_message.reply_text(message)
+        status = controller.status()
+        await update.effective_message.reply_text(f"Application is {status.state.value}.")
     except Exception:
         logger.exception("Error handling /status")
         await update.effective_message.reply_text("Failed to retrieve status.")

--- a/src/app/controller.py
+++ b/src/app/controller.py
@@ -1,41 +1,109 @@
-"""Application-level business logic."""
+"""Application-level business logic and task management."""
 
 from __future__ import annotations
 
+import asyncio
 import logging
+import os
+from dataclasses import dataclass
+from enum import Enum
+from typing import Dict
+
+from .api_client import BybitP2PClient
 
 logger = logging.getLogger(__name__)
 
 
+class AppState(Enum):
+    """Represents the running state of the application."""
+
+    RUNNING = "running"
+    STOPPED = "stopped"
+
+
+@dataclass(frozen=True)
+class ControllerStatus:
+    """Structured status response returned by controller methods."""
+
+    state: AppState
+    tasks: tuple[str, ...]
+
+
 class AppController:
-    """Encapsulates simple application state.
+    """Coordinate background tasks and the Bybit P2P client."""
 
-    The controller exposes methods that can be triggered from the Telegram bot
-    handlers. In a real application this would coordinate services and contain
-    the business rules.
-    """
+    _DEFAULT_POLL_INTERVAL = 60.0
 
-    def __init__(self) -> None:
-        self._running = False
+    def __init__(self, client: BybitP2PClient, *, poll_interval: float | None = None) -> None:
+        self._client = client
+        self._tasks: Dict[str, asyncio.Task] = {}
 
-    def start(self) -> str:
-        """Start the application."""
-        if not self._running:
-            self._running = True
-            logger.info("Application started")
-            return "Application started."
-        logger.info("Start requested while already running")
-        return "Application is already running."
+        if poll_interval is None:
+            interval_env = os.getenv("APP_POLL_INTERVAL")
+            if interval_env is None:
+                poll_interval = self._DEFAULT_POLL_INTERVAL
+            else:
+                poll_interval = float(interval_env)
+        self._poll_interval = poll_interval
 
-    def stop(self) -> str:
-        """Stop the application."""
-        if self._running:
-            self._running = False
-            logger.info("Application stopped")
-            return "Application stopped."
-        logger.info("Stop requested while not running")
-        return "Application is not running."
+    # ------------------------------------------------------------------
+    # Task management helpers
+    # ------------------------------------------------------------------
+    async def _poll_orders(self) -> None:
+        """Periodically poll the latest order.
 
-    def status(self) -> str:
-        """Return the running status."""
-        return "Application is running." if self._running else "Application is stopped."
+        The loop runs until cancelled. It intentionally swallows the
+        ``CancelledError`` so that cancellation is clean and silent.
+        """
+
+        try:
+            while True:
+                try:
+                    self._client.get_latest_order()
+                except Exception:  # pragma: no cover - client errors logged
+                    logger.exception("Error polling latest order")
+                await asyncio.sleep(self._poll_interval)
+        except asyncio.CancelledError:
+            logger.info("Polling task cancelled")
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+    def start(self) -> ControllerStatus:
+        """Start background tasks if not already running."""
+
+        if self._tasks:
+            logger.info("Start requested but tasks already running")
+            return self.status()
+
+        loop = asyncio.get_running_loop()
+        self._tasks["order_polling"] = loop.create_task(self._poll_orders())
+        logger.info("Application started with %d task(s)", len(self._tasks))
+        return self.status()
+
+    def stop(self) -> ControllerStatus:
+        """Cancel all running tasks."""
+
+        if not self._tasks:
+            logger.info("Stop requested but no running tasks")
+            return self.status()
+
+        tasks = list(self._tasks.values())
+        for task in tasks:
+            task.cancel()
+
+        self._tasks.clear()
+        asyncio.get_running_loop().create_task(self._await_tasks(tasks))
+        logger.info("Application stopped")
+        return self.status()
+
+    async def _await_tasks(self, tasks: list[asyncio.Task]) -> None:
+        """Wait for a collection of tasks to finish."""
+
+        await asyncio.gather(*tasks, return_exceptions=True)
+
+    def status(self) -> ControllerStatus:
+        """Return the current controller status."""
+
+        state = AppState.RUNNING if self._tasks else AppState.STOPPED
+        return ControllerStatus(state=state, tasks=tuple(self._tasks.keys()))

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -1,17 +1,46 @@
 """Tests for the AppController class."""
 
-from src.app.controller import AppController
+from __future__ import annotations
+
+import asyncio
+
+from src.app.controller import AppController, AppState
+
+
+class DummyClient:
+    """Lightweight stub for ``BybitP2PClient`` used in tests."""
+
+    def get_latest_order(self) -> None:  # pragma: no cover - no logic needed
+        return None
 
 
 def test_start_and_status() -> None:
-    controller = AppController()
-    assert controller.status() == "Application is stopped."
-    assert controller.start() == "Application started."
-    assert controller.status() == "Application is running."
+    async def run() -> None:
+        controller = AppController(DummyClient())
+        assert controller.status().state == AppState.STOPPED
+
+        start_status = controller.start()
+        assert start_status.state == AppState.RUNNING
+        assert len(start_status.tasks) == 1
+
+        duplicate_status = controller.start()
+        assert duplicate_status.state == AppState.RUNNING
+        assert len(duplicate_status.tasks) == 1
+
+        stop_status = controller.stop()
+        await asyncio.sleep(0)  # allow cancelled tasks to finish
+        assert stop_status.state == AppState.STOPPED
+
+    asyncio.run(run())
 
 
 def test_stop() -> None:
-    controller = AppController()
-    controller.start()
-    assert controller.stop() == "Application stopped."
-    assert controller.status() == "Application is stopped."
+    async def run() -> None:
+        controller = AppController(DummyClient())
+        controller.start()
+        stop_status = controller.stop()
+        await asyncio.sleep(0)
+        assert stop_status.state == AppState.STOPPED
+        assert controller.status().tasks == ()
+
+    asyncio.run(run())


### PR DESCRIPTION
## Summary
- Expand `AppController` to manage background tasks and a `BybitP2PClient`
- Return structured status via `AppState` enum and `ControllerStatus` dataclass
- Adapt bot handlers and tests to the new controller interface

## Testing
- `ruff check src/app/controller.py src/app/bot/handlers.py tests/test_controller.py`
- `black --check src/app/controller.py src/app/bot/handlers.py tests/test_controller.py`
- `PYTHONPATH=. pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689f9e7ea774832892ad3df26931509a