### PR TITLE
Load settings from YAML

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,4 @@
+BYBIT_API_KEY=your-api-key
+BYBIT_API_SECRET=your-api-secret
+TG_BOT_TOKEN=your-telegram-token
+TG_ADMIN_ID=123456789

--- a/README.md
+++ b/README.md
@@ -16,18 +16,41 @@ make lint
 
 ## Configuration
 
-Set the following environment variables or place them in a `.env` file:
+Application options are split between a versioned YAML file and private environment variables.
+
+### `config.yaml`
+
+Non‑secret settings live in `config.yaml` at the project root:
+
+```yaml
+bybit:
+  testnet: false
+  recv_window: 20000
+
+polling:
+  price: 60
+  balance: 300
+
+payments:
+  min_match_count: 1
+  mappings:
+    USDT_UAH: MonoBank
+```
+
+Set `bybit.testnet` to `true` to target the Bybit testnet environment. `recv_window` controls the request receive window in milliseconds.
+
+### Environment variables
+
+API credentials and bot secrets are loaded from the environment (or a local `.env` file). Copy `.env.example` to `.env` and fill in the values:
 
 ```
 BYBIT_API_KEY=<your api key>
 BYBIT_API_SECRET=<your api secret>
-BYBIT_TESTNET=false  # optional
-BYBIT_RECV_WINDOW=20000  # optional
+TG_BOT_TOKEN=<telegram bot token>
+TG_ADMIN_ID=<telegram admin id>
 ```
 
-`BYBIT_TESTNET` should be `true` when using the Bybit testnet environment.
-
-`BYBIT_RECV_WINDOW` controls the request receive window in milliseconds.
+`BYBIT_API_KEY` and `BYBIT_API_SECRET` authenticate requests to Bybit. `TG_BOT_TOKEN` and `TG_ADMIN_ID` configure the Telegram bot.
 
 ## Protected directories (DO NOT EDIT)
 

--- a/config.yaml
+++ b/config.yaml
@@ -1,0 +1,12 @@
+bybit:
+  testnet: false
+  recv_window: 20000
+
+polling:
+  price: 60
+  balance: 300
+
+payments:
+  min_match_count: 1
+  mappings:
+    USDT_UAH: "MonoBank"

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ python-dotenv
 requests==2.32.4
 requests-toolbelt==1.0.0
 python-telegram-bot==20.7
+PyYAML>=6.0

--- a/src/app/config.py
+++ b/src/app/config.py
@@ -3,47 +3,58 @@
 from __future__ import annotations
 
 import os
-from dataclasses import dataclass
+from dataclasses import dataclass, field
+from typing import Any, Dict
 
+import yaml
 from dotenv import load_dotenv
-
-load_dotenv()
-
-
-def _env_bool(name: str, default: bool = False) -> bool:
-    return os.getenv(name, str(default)).lower() in {"1", "true", "yes"}
-
-
-def _env_int(name: str, default: int) -> int:
-    try:
-        return int(os.getenv(name, str(default)))
-    except ValueError:
-        return default
 
 
 @dataclass
 class Settings:
-    """Holds configuration loaded from environment variables."""
+    """Holds configuration loaded from config.yaml and environment variables."""
 
     api_key: str
     api_secret: str
     testnet: bool = False
     recv_window: int = 20000
+    poll_interval_price: int = 60
+    poll_interval_balance: int = 300
+    min_payment_method_matches: int = 1
+    payment_methods: Dict[str, str] = field(default_factory=dict)
 
     @classmethod
-    def from_env(cls) -> "Settings":
-        """Create settings from environment variables."""
+    def from_file(cls, path: str = "config.yaml") -> "Settings":
+        """Create settings from a YAML file and environment variables."""
+        load_dotenv()
+        with open(path, "r", encoding="utf-8") as fh:
+            data = yaml.safe_load(fh) or {}
+
+        bybit_cfg = data.get("bybit", {})
+        polling_cfg = data.get("polling", {})
+        payments_cfg = data.get("payments", {})
+
         api_key = os.getenv("BYBIT_API_KEY")
         api_secret = os.getenv("BYBIT_API_SECRET")
         if not api_key or not api_secret:
             raise RuntimeError(
-                "BYBIT_API_KEY and BYBIT_API_SECRET environment variables are required",
+                "BYBIT_API_KEY and BYBIT_API_SECRET environment variables are required"
             )
-        testnet = _env_bool("BYBIT_TESTNET")
-        recv_window = _env_int("BYBIT_RECV_WINDOW", 20000)
+
+        def _positive_int(value: Any, default: int) -> int:
+            try:
+                ivalue = int(value)
+                return ivalue if ivalue > 0 else default
+            except (TypeError, ValueError):
+                return default
+
         return cls(
             api_key=api_key,
             api_secret=api_secret,
-            testnet=testnet,
-            recv_window=recv_window,
+            testnet=bool(bybit_cfg.get("testnet", False)),
+            recv_window=_positive_int(bybit_cfg.get("recv_window"), 20000),
+            poll_interval_price=_positive_int(polling_cfg.get("price"), 60),
+            poll_interval_balance=_positive_int(polling_cfg.get("balance"), 300),
+            min_payment_method_matches=_positive_int(payments_cfg.get("min_match_count"), 1),
+            payment_methods=payments_cfg.get("mappings", {}) or {},
         )

--- a/src/app/main.py
+++ b/src/app/main.py
@@ -1,7 +1,8 @@
 """Entry point for the sample application."""
 
-import json
 from pprint import pprint
+
+from pathlib import Path
 
 from .api_client import BybitP2PClient
 from .config import Settings
@@ -9,7 +10,7 @@ from .config import Settings
 
 def main() -> None:
     """Run the application."""
-    settings = Settings.from_env()
+    settings = Settings.from_file(Path(__file__).resolve().parents[1] / "config.yaml")
     client = BybitP2PClient(
         settings.api_key,
         settings.api_secret,
@@ -20,21 +21,17 @@ def main() -> None:
     # pprint(order)
 
     for s in ("0", "1"):  # None = both, 0 = BUY, 1 = SELL
-      beginTime = "1751328000000"  # 2025-07-01 00:00:00 UTC
-      endTime   = "1754006399999"  # 2025-07-31 23:59:59 UTC
+        resp = client._client.get_orders(
+            page="1",
+            size="10",
+            # tokenId="USDT",
+            # status="50",  # Completed
+            # side=s,  # None, 0, or 1
+            # beginTime=beginTime,
+            # endTime=endTime,
+        )
 
-      resp = client._client.get_orders(
-          page="1",
-          size="10",
-          # tokenId="USDT",
-          # status="50",  # Completed
-          # side=s,  # None, 0, or 1
-          # beginTime=beginTime,
-          # endTime=endTime,
-      )
-
-      pprint(resp)
-
+        pprint(resp)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- load non-secret settings from `config.yaml`
- expose secret requirements via `.env.example`
- document YAML config and environment split in README

## Testing
- `black --check src/app/config.py src/app/main.py scripts/collect_p2p_examples.py`
- `ruff check src/app/config.py src/app/main.py scripts/collect_p2p_examples.py`
- `PYTHONPATH=. pytest`


------
https://chatgpt.com/codex/tasks/task_e_689fa62159ec8328b69292f2e30b37b1