### PR TITLE
Add minimal Bybit P2P project skeleton

### DIFF
--- a/app/client/bybit.py
+++ b/app/client/bybit.py
@@ -1,0 +1,8 @@
+"""Bybit P2P client helpers."""
+
+from bybit_p2p import P2P
+
+
+def get_api(config: dict) -> P2P:
+    """Instantiate a Bybit P2P API client from config."""
+    return P2P(api_key=config["api_key"], api_secret=config["api_secret"])

--- a/app/config.py
+++ b/app/config.py
@@ -1,0 +1,19 @@
+"""Configuration utilities for the Bybit P2P client."""
+
+from os import getenv
+
+try:  # Prefer local .env when available
+    from dotenv import load_dotenv
+
+    load_dotenv()
+except Exception:  # pragma: no cover - dotenv is optional
+    pass
+
+
+def load_config() -> dict:
+    """Load required API settings from environment variables."""
+    api_key = getenv("BYBIT_API_KEY")
+    api_secret = getenv("BYBIT_API_SECRET")
+    if not api_key or not api_secret:
+        raise RuntimeError("BYBIT_API_KEY and BYBIT_API_SECRET must be set")
+    return {"api_key": api_key, "api_secret": api_secret}

--- a/main.py
+++ b/main.py
@@ -1,0 +1,14 @@
+"""Entrypoint for the Bybit P2P project."""
+
+from app.client.bybit import get_api
+from app.config import load_config
+
+
+def main() -> None:
+    config = load_config()
+    client = get_api(config)
+    print(client.get_pending_orders())
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -1,6 +1,6 @@
 """Smoke tests for the sample application."""
 
-from src.app import main
+import main
 
 
 def test_main_callable() -> None:


### PR DESCRIPTION
## Summary
- scaffold config loader to pull API credentials from environment
- add Bybit P2P client factory and minimal main entrypoint
- adjust smoke test to import the new entrypoint

## Testing
- `python -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a7a90f2de48328ac4c92c7a23b7fee