### PR TITLE
Centralize recv window config for Bybit client

### DIFF
--- a/app/client/bybit.py
+++ b/app/client/bybit.py
@@ -1,0 +1,13 @@
+"""Bybit P2P client helpers."""
+
+from bybit_p2p import P2P
+
+
+def get_api(*, api_key: str, api_secret: str, testnet: bool, recv_window: int) -> P2P:
+    """Instantiate a Bybit P2P API client."""
+    return P2P(
+        testnet=testnet,
+        api_key=api_key,
+        api_secret=api_secret,
+        recv_window=recv_window,
+    )

--- a/app/config.py
+++ b/app/config.py
@@ -1,0 +1,26 @@
+"""Configuration utilities for the Bybit P2P client."""
+
+from os import getenv
+
+try:  # Prefer local .env when available
+    from dotenv import load_dotenv
+
+    load_dotenv()
+except Exception:  # pragma: no cover - dotenv is optional
+    pass
+
+
+def load_config() -> dict:
+    """Load API credentials and flags from environment variables."""
+    api_key = getenv("BYBIT_API_KEY")
+    api_secret = getenv("BYBIT_API_SECRET")
+    testnet = getenv("BYBIT_TESTNET", "false").lower() in {"1", "true", "yes"}
+    recv_window = int(getenv("BYBIT_RECV_WINDOW", "20000"))
+    if not api_key or not api_secret:
+        raise RuntimeError("BYBIT_API_KEY and BYBIT_API_SECRET must be set")
+    return {
+        "api_key": api_key,
+        "api_secret": api_secret,
+        "testnet": testnet,
+        "recv_window": recv_window,
+    }

--- a/main.py
+++ b/main.py
@@ -1,0 +1,19 @@
+"""Entrypoint for the Bybit P2P project."""
+
+from app.client.bybit import get_api
+from app.config import load_config
+
+
+def main() -> None:
+    config = load_config()
+    client = get_api(
+        api_key=config["api_key"],
+        api_secret=config["api_secret"],
+        testnet=config["testnet"],
+        recv_window=config["recv_window"],
+    )
+    print(client.get_pending_orders())
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -1,6 +1,6 @@
 """Smoke tests for the sample application."""
 
-from src.app import main
+import main
 
 
 def test_main_callable() -> None:


### PR DESCRIPTION
## Summary
- extend config loader to read `BYBIT_RECV_WINDOW` with a 20s default
- pass API credentials, testnet flag, and recv window explicitly into client setup

## Testing
- `python -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a7a90f2de48328ac4c92c7a23b7fee